### PR TITLE
Update css/layout.css

### DIFF
--- a/css/layout.css
+++ b/css/layout.css
@@ -286,7 +286,7 @@ h2{
 iframe{
 	border: none;
 	height: 100%;
-	width: 100%;
+	width: 99%;
 }
 
 iframe body{


### PR DESCRIPTION
this seems to solve the display issue in FF7.0.1 (issue #21). In FF7.0.1, the iframe gets displayed below the themeroller-mobile instead of next to it.
