### PR TITLE
fixing crash of download zip on localhosts

### DIFF
--- a/zip.php
+++ b/zip.php
@@ -41,7 +41,7 @@
 	
 	$zip = new ZipArchive();
 
-    if(!is_dir('zips')){
+	if(!is_dir('zips')){
 		mkdir('zips');
 	}
 


### PR DESCRIPTION
I threw in an if statement that checks if the zips directory exists and if not, creates it. Problem more deeply described in this post:
http://jonathanmh.com/running-jquery-mobile-themeroller-on-localhost/
