### PR TITLE
Fix retina black icons and correctly change color of alternative icons (.ui-icon-alt)

### DIFF
--- a/jqm/1.0.1/jqm.default.theme.css
+++ b/jqm/1.0.1/jqm.default.theme.css
@@ -864,7 +864,7 @@ a.ui-link-inherit {
 .ui-icon-alt {
 	background: 						#fff;
 	background: 						rgba(255,255,255,.3);
-	background-image: url(images/icons-18-black.png);
+	background-image: url(images/icons-18-black.png) /*{global-icon-alt-set}*/;
 	background-repeat: no-repeat;
 }
 
@@ -887,7 +887,7 @@ a.ui-link-inherit {
 		background-size: 776px 18px;
 	}
 	.ui-icon-alt {
-		background-image: url(images/icons-36-black.png);
+		background-image: url(images/icons-36-black.png) /*{global-large-icon-alt-set}*/;
 	}
 }
 

--- a/jqm/1.0.1/jqm.starter.theme.css
+++ b/jqm/1.0.1/jqm.starter.theme.css
@@ -301,7 +301,7 @@ a.ui-link-inherit {
 .ui-icon-alt {
 	background: 						#fff;
 	background: 						rgba(255,255,255,.3);
-	background-image: url(images/icons-18-black.png);
+	background-image: url(images/icons-18-black.png) /*{global-icon-alt-set}*/;
 	background-repeat: no-repeat;
 }
 
@@ -324,7 +324,7 @@ a.ui-link-inherit {
 		background-size: 776px 18px;
 	}
 	.ui-icon-alt {
-		background-image: url(images/icons-36-black.png);
+		background-image: url(images/icons-36-black.png) /*{global-large-icon-alt-set}*/;
 	}
 }
 

--- a/jqm/1.1.0/jqm.default.theme.css
+++ b/jqm/1.1.0/jqm.default.theme.css
@@ -887,7 +887,7 @@ a.ui-link-inherit {
 .ui-icon-alt {
 	background: 						#fff;
 	background: 						rgba(255,255,255,.3);
-	background-image: url(images/icons-18-black.png);
+	background-image: url(images/icons-18-black.png) /*{global-icon-alt-set}*/;
 	background-repeat: no-repeat;
 }
 
@@ -910,7 +910,7 @@ a.ui-link-inherit {
 		background-size: 776px 18px;
 	}
 	.ui-icon-alt {
-		background-image: url(images/icons-36-black.png);
+		background-image: url(images/icons-36-black.png) /*{global-large-icon-alt-set}*/;
 	}
 }
 

--- a/jqm/1.1.0/jqm.starter.theme.css
+++ b/jqm/1.1.0/jqm.starter.theme.css
@@ -309,7 +309,7 @@ a.ui-link-inherit {
 .ui-icon-alt {
 	background: 						#fff;
 	background: 						rgba(255,255,255,.3);
-	background-image: url(images/icons-18-black.png);
+	background-image: url(images/icons-18-black.png) /*{global-icon-alt-set}*/;
 	background-repeat: no-repeat;
 }
 
@@ -332,7 +332,7 @@ a.ui-link-inherit {
 		background-size: 776px 18px;
 	}
 	.ui-icon-alt {
-		background-image: url(images/icons-36-black.png);
+		background-image: url(images/icons-36-black.png) /*{global-large-icon-alt-set}*/;
 	}
 }
 

--- a/jqm/1.1.1/jqm.default.theme.css
+++ b/jqm/1.1.1/jqm.default.theme.css
@@ -914,7 +914,7 @@ a.ui-link-inherit {
 .ui-icon-alt {
 	background: 						#fff;
 	background: 						rgba(255,255,255,.3);
-	background-image: url(images/icons-18-black.png);
+	background-image: url(images/icons-18-black.png) /*{global-icon-alt-set}*/;
 	background-repeat: no-repeat;
 }
 
@@ -930,14 +930,14 @@ a.ui-link-inherit {
 	.ui-icon-gear, .ui-icon-refresh, .ui-icon-forward, .ui-icon-back,
 	.ui-icon-grid, .ui-icon-star, .ui-icon-alert, .ui-icon-info, .ui-icon-home, .ui-icon-search, .ui-icon-searchfield:after, 
 	.ui-icon-checkbox-off, .ui-icon-checkbox-on, .ui-icon-radio-off, .ui-icon-radio-on {
-		background-image: url(images/icons-36-white.png);
+		background-image: url(images/icons-36-white.png) /*{global-large-icon-set}*/;
 		-moz-background-size: 776px 18px;
 		-o-background-size: 776px 18px;
 		-webkit-background-size: 776px 18px;
 		background-size: 776px 18px;
 	}
 	.ui-icon-alt {
-		background-image: url(images/icons-36-black.png);
+		background-image: url(images/icons-36-black.png) /*{global-large-icon-alt-set}*/;
 	}
 }
 

--- a/jqm/1.1.1/jqm.starter.theme.css
+++ b/jqm/1.1.1/jqm.starter.theme.css
@@ -315,7 +315,7 @@ a.ui-link-inherit {
 .ui-icon-alt {
 	background: 						#fff;
 	background: 						rgba(255,255,255,.3);
-	background-image: url(images/icons-18-black.png);
+	background-image: url(images/icons-18-black.png) /*{global-icon-alt-set}*/;
 	background-repeat: no-repeat;
 }
 
@@ -331,14 +331,14 @@ a.ui-link-inherit {
 	.ui-icon-gear, .ui-icon-refresh, .ui-icon-forward, .ui-icon-back,
 	.ui-icon-grid, .ui-icon-star, .ui-icon-alert, .ui-icon-info, .ui-icon-home, .ui-icon-search, .ui-icon-searchfield:after, 
 	.ui-icon-checkbox-off, .ui-icon-checkbox-on, .ui-icon-radio-off, .ui-icon-radio-on {
-		background-image: url(images/icons-36-white.png);
+		background-image: url(images/icons-36-white.png) /*{global-large-icon-set}*/;
 		-moz-background-size: 776px 18px;
 		-o-background-size: 776px 18px;
 		-webkit-background-size: 776px 18px;
 		background-size: 776px 18px;
 	}
 	.ui-icon-alt {
-		background-image: url(images/icons-36-black.png);
+		background-image: url(images/icons-36-black.png) /*{global-large-icon-alt-set}*/;
 	}
 }
 

--- a/jqm/1.1.2/jqm.default.theme.css
+++ b/jqm/1.1.2/jqm.default.theme.css
@@ -911,7 +911,7 @@ a.ui-link-inherit {
 .ui-icon-alt {
 	background: 						#fff;
 	background: 						rgba(255,255,255,.3);
-	background-image: url(images/icons-18-black.png);
+	background-image: url(images/icons-18-black.png) /*{global-icon-alt-set}*/;
 	background-repeat: no-repeat;
 }
 
@@ -927,14 +927,14 @@ a.ui-link-inherit {
 	.ui-icon-gear, .ui-icon-refresh, .ui-icon-forward, .ui-icon-back,
 	.ui-icon-grid, .ui-icon-star, .ui-icon-alert, .ui-icon-info, .ui-icon-home, .ui-icon-search, .ui-icon-searchfield:after, 
 	.ui-icon-checkbox-off, .ui-icon-checkbox-on, .ui-icon-radio-off, .ui-icon-radio-on {
-		background-image: url(images/icons-36-white.png);
+		background-image: url(images/icons-36-white.png) /*{global-large-icon-set}*/;
 		-moz-background-size: 776px 18px;
 		-o-background-size: 776px 18px;
 		-webkit-background-size: 776px 18px;
 		background-size: 776px 18px;
 	}
 	.ui-icon-alt {
-		background-image: url(images/icons-36-black.png);
+		background-image: url(images/icons-36-black.png) /*{global-large-icon-alt-set}*/;
 	}
 }
 

--- a/jqm/1.1.2/jqm.starter.theme.css
+++ b/jqm/1.1.2/jqm.starter.theme.css
@@ -312,7 +312,7 @@ a.ui-link-inherit {
 .ui-icon-alt {
 	background: 						#fff;
 	background: 						rgba(255,255,255,.3);
-	background-image: url(images/icons-18-black.png);
+	background-image: url(images/icons-18-black.png) /*{global-icon-alt-set}*/;
 	background-repeat: no-repeat;
 }
 
@@ -328,14 +328,14 @@ a.ui-link-inherit {
 	.ui-icon-gear, .ui-icon-refresh, .ui-icon-forward, .ui-icon-back,
 	.ui-icon-grid, .ui-icon-star, .ui-icon-alert, .ui-icon-info, .ui-icon-home, .ui-icon-search, .ui-icon-searchfield:after, 
 	.ui-icon-checkbox-off, .ui-icon-checkbox-on, .ui-icon-radio-off, .ui-icon-radio-on {
-		background-image: url(images/icons-36-white.png);
+		background-image: url(images/icons-36-white.png) /*{global-large-icon-set}*/;
 		-moz-background-size: 776px 18px;
 		-o-background-size: 776px 18px;
 		-webkit-background-size: 776px 18px;
 		background-size: 776px 18px;
 	}
 	.ui-icon-alt {
-		background-image: url(images/icons-36-black.png);
+		background-image: url(images/icons-36-black.png) /*{global-large-icon-alt-set}*/;
 	}
 }
 

--- a/jqm/1.2.0/jqm.default.theme.css
+++ b/jqm/1.2.0/jqm.default.theme.css
@@ -915,7 +915,7 @@ a.ui-link-inherit {
 .ui-icon-alt {
 	background: 						#fff;
 	background: 						rgba(255,255,255,.3);
-	background-image: url(images/icons-18-black.png);
+	background-image: url(images/icons-18-black.png) /*{global-icon-alt-set}*/;
 	background-repeat: no-repeat;
 }
 
@@ -931,14 +931,14 @@ a.ui-link-inherit {
 	.ui-icon-gear, .ui-icon-refresh, .ui-icon-forward, .ui-icon-back,
 	.ui-icon-grid, .ui-icon-star, .ui-icon-alert, .ui-icon-info, .ui-icon-home, .ui-icon-search, .ui-icon-searchfield:after, 
 	.ui-icon-checkbox-off, .ui-icon-checkbox-on, .ui-icon-radio-off, .ui-icon-radio-on {
-		background-image: url(images/icons-36-white.png);
+		background-image: url(images/icons-36-white.png) /*{global-large-icon-set}*/;
 		-moz-background-size: 776px 18px;
 		-o-background-size: 776px 18px;
 		-webkit-background-size: 776px 18px;
 		background-size: 776px 18px;
 	}
 	.ui-icon-alt {
-		background-image: url(images/icons-36-black.png);
+		background-image: url(images/icons-36-black.png) /*{global-large-icon-alt-set}*/;
 	}
 }
 

--- a/jqm/1.2.0/jqm.starter.theme.css
+++ b/jqm/1.2.0/jqm.starter.theme.css
@@ -314,7 +314,7 @@ a.ui-link-inherit {
 .ui-icon-alt {
 	background: 						#fff;
 	background: 						rgba(255,255,255,.3);
-	background-image: url(images/icons-18-black.png);
+	background-image: url(images/icons-18-black.png) /*{global-icon-alt-set}*/;
 	background-repeat: no-repeat;
 }
 
@@ -330,14 +330,14 @@ a.ui-link-inherit {
 	.ui-icon-gear, .ui-icon-refresh, .ui-icon-forward, .ui-icon-back,
 	.ui-icon-grid, .ui-icon-star, .ui-icon-alert, .ui-icon-info, .ui-icon-home, .ui-icon-search, .ui-icon-searchfield:after, 
 	.ui-icon-checkbox-off, .ui-icon-checkbox-on, .ui-icon-radio-off, .ui-icon-radio-on {
-		background-image: url(images/icons-36-white.png);
+		background-image: url(images/icons-36-white.png) /*{global-large-icon-set}*/;
 		-moz-background-size: 776px 18px;
 		-o-background-size: 776px 18px;
 		-webkit-background-size: 776px 18px;
 		background-size: 776px 18px;
 	}
 	.ui-icon-alt {
-		background-image: url(images/icons-36-black.png);
+		background-image: url(images/icons-36-black.png) /*{global-large-icon-alt-set}*/;
 	}
 }
 

--- a/jqm/1.2.1/jqm.default.theme.css
+++ b/jqm/1.2.1/jqm.default.theme.css
@@ -915,7 +915,7 @@ a.ui-link-inherit {
 .ui-icon-alt {
 	background: 						#fff;
 	background: 						rgba(255,255,255,.3);
-	background-image: url(images/icons-18-black.png);
+	background-image: url(images/icons-18-black.png) /*{global-icon-alt-set}*/;
 	background-repeat: no-repeat;
 }
 
@@ -931,14 +931,14 @@ a.ui-link-inherit {
 	.ui-icon-gear, .ui-icon-refresh, .ui-icon-forward, .ui-icon-back,
 	.ui-icon-grid, .ui-icon-star, .ui-icon-alert, .ui-icon-info, .ui-icon-home, .ui-icon-search, .ui-icon-searchfield:after, 
 	.ui-icon-checkbox-off, .ui-icon-checkbox-on, .ui-icon-radio-off, .ui-icon-radio-on {
-		background-image: url(images/icons-36-white.png);
+		background-image: url(images/icons-36-white.png) /*{global-large-icon-set}*/;
 		-moz-background-size: 776px 18px;
 		-o-background-size: 776px 18px;
 		-webkit-background-size: 776px 18px;
 		background-size: 776px 18px;
 	}
 	.ui-icon-alt {
-		background-image: url(images/icons-36-black.png);
+		background-image: url(images/icons-36-black.png) /*{global-large-icon-alt-set}*/;
 	}
 }
 

--- a/jqm/1.2.1/jqm.starter.theme.css
+++ b/jqm/1.2.1/jqm.starter.theme.css
@@ -314,7 +314,7 @@ a.ui-link-inherit {
 .ui-icon-alt {
 	background: 						#fff;
 	background: 						rgba(255,255,255,.3);
-	background-image: url(images/icons-18-black.png);
+	background-image: url(images/icons-18-black.png) /*{global-icon-alt-set}*/;
 	background-repeat: no-repeat;
 }
 
@@ -330,14 +330,14 @@ a.ui-link-inherit {
 	.ui-icon-gear, .ui-icon-refresh, .ui-icon-forward, .ui-icon-back,
 	.ui-icon-grid, .ui-icon-star, .ui-icon-alert, .ui-icon-info, .ui-icon-home, .ui-icon-search, .ui-icon-searchfield:after, 
 	.ui-icon-checkbox-off, .ui-icon-checkbox-on, .ui-icon-radio-off, .ui-icon-radio-on {
-		background-image: url(images/icons-36-white.png);
+		background-image: url(images/icons-36-white.png) /*{global-large-icon-set}*/;
 		-moz-background-size: 776px 18px;
 		-o-background-size: 776px 18px;
 		-webkit-background-size: 776px 18px;
 		background-size: 776px 18px;
 	}
 	.ui-icon-alt {
-		background-image: url(images/icons-36-black.png);
+		background-image: url(images/icons-36-black.png) /*{global-large-icon-alt-set}*/;
 	}
 }
 

--- a/jqm/1.3.0/jqm.default.theme.css
+++ b/jqm/1.3.0/jqm.default.theme.css
@@ -855,7 +855,7 @@ a.ui-link-inherit {
 .ui-icon-alt .ui-icon-searchfield:after {
 	background-color: 						#fff;
 	background-color: 						rgba(255,255,255,.3);
-	background-image: url(images/icons-18-black.png);
+	background-image: url(images/icons-18-black.png) /*{global-icon-alt-set}*/;
 	background-repeat: no-repeat;
 }
 
@@ -967,7 +967,7 @@ a.ui-link-inherit {
 	.ui-icon-grid, .ui-icon-star, .ui-icon-alert, .ui-icon-info, .ui-icon-home, .ui-icon-bars, .ui-icon-edit,
 	.ui-icon-search, .ui-icon-searchfield:after, 
 	.ui-icon-checkbox-off, .ui-icon-checkbox-on, .ui-icon-radio-off, .ui-icon-radio-on {
-		background-image: url(images/icons-36-white.png);
+		background-image: url(images/icons-36-white.png) /*{global-large-icon-set}*/;
 		-moz-background-size: 864px 18px;
 		-o-background-size: 864px 18px;
 		-webkit-background-size: 864px 18px;
@@ -975,7 +975,7 @@ a.ui-link-inherit {
 	}
 
 	.ui-icon-alt .ui-icon {
-		background-image: url(images/icons-36-black.png);
+		background-image: url(images/icons-36-black.png) /*{global-large-icon-alt-set}*/;
 	}
 
 	.ui-icon-plus {

--- a/jqm/1.3.0/jqm.starter.theme.css
+++ b/jqm/1.3.0/jqm.starter.theme.css
@@ -254,7 +254,7 @@ a.ui-link-inherit {
 .ui-icon-alt .ui-icon-searchfield:after {
 	background-color: 						#fff;
 	background-color: 						rgba(255,255,255,.3);
-	background-image: url(images/icons-18-black.png);
+	background-image: url(images/icons-18-black.png) /*{global-icon-alt-set}*/;
 	background-repeat: no-repeat;
 }
 
@@ -366,7 +366,7 @@ a.ui-link-inherit {
 	.ui-icon-grid, .ui-icon-star, .ui-icon-alert, .ui-icon-info, .ui-icon-home, .ui-icon-bars, .ui-icon-edit,
 	.ui-icon-search, .ui-icon-searchfield:after, 
 	.ui-icon-checkbox-off, .ui-icon-checkbox-on, .ui-icon-radio-off, .ui-icon-radio-on {
-		background-image: url(images/icons-36-white.png);
+		background-image: url(images/icons-36-white.png) /*{global-large-icon-set}*/;
 		-moz-background-size: 864px 18px;
 		-o-background-size: 864px 18px;
 		-webkit-background-size: 864px 18px;
@@ -374,7 +374,7 @@ a.ui-link-inherit {
 	}
 
 	.ui-icon-alt .ui-icon {
-		background-image: url(images/icons-36-black.png);
+		background-image: url(images/icons-36-black.png) /*{global-large-icon-alt-set}*/;
 	}
 
 	.ui-icon-plus {

--- a/js/app.js
+++ b/js/app.js
@@ -611,6 +611,11 @@ TR.initControls = function() {
     $( "[data-type=icon_set]" ).bind( "blur mouseup", function() {
         TR.styleArray[$( this ).attr( "data-name" )] = "url(images/icons-18-" + this.value + ".png)";
         TR.styleArray["global-large-icon-set"] = "url(images/icons-36-" + this.value + ".png)";
+
+        var iconalt = (this.value == 'white') ? 'black' : 'white';
+        TR.styleArray["global-icon-alt-set"] = "url(images/icons-18-" + iconalt + ".png)";
+        TR.styleArray["global-large-icon-alt-set"] = "url(images/icons-36-" + iconalt + ".png)";
+
         TR.updateAllCSS();
     });
 


### PR DESCRIPTION
This patch fix retina black icons (currently retina icons are changed for 1.0.1 and 1.1.0 themes only) and correctly alternate url for .ui-icon-alt image.
