### PR TITLE
Fixed a bug that CSS styles isn't applied properly when the theme version is upgraded or downgraded via "Switch to version" of toolbar.

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1252,7 +1252,7 @@ TR.initStyleArray = function( refresh ) {
                 ref: reference
             };
             //update TR.styleArray
-            if( refresh != "refresh" ) {
+            if( refresh !== "refresh" || (refresh === "refresh" && TR.styleArray[reference] === undefined) ) {
                 TR.styleArray[reference] = TR.tokens[i-1].value.replace( /\/\*.*\*\//, "" ).trim();
             }
             //cut off string and continue


### PR DESCRIPTION
Hi~!

As you know, TR.styleArray has the class references and values for each theme version.
Until now, if the theme is changed among versions, ThemeRoller seems to change TR.styleBlock and doesn't seem to update TR.styleArray.
But TR.styleArray should be updated on 1.4.0 version, in case of changing the theme version.
Hence, I'll do that PR to add the references to the TR.styleArray, if references don’t exist in the target TR.styleArray.

If there are any problems or mistakes on that PR, please let me know.
Thanks in advance.
