### PR TITLE
Fix PHP 5.4 syntax to PHP 5.3 syntax

### DIFF
--- a/zip.php
+++ b/zip.php
@@ -117,10 +117,9 @@
 		$JQM_ICONS_LINK = "\n	" . $JQM_ICONS_TAG;
 		$JQM_ICONS_LINK_DOC = "\n<strong>" .
 			preg_replace(
-				[ '/["]/', "/[<]/", "/[>]/" ],
-				[ "&quot;", "&lt;", "&gt;" ],
-				$JQM_ICONS_TAG ) .
-			"</strong>";
+				array( '/["]/', "/[<]/", "/[>]/" ),
+				array( "&quot;", "&lt;", "&gt;" ),
+				$JQM_ICONS_TAG );
 	}
 
 	$zip->addFromString("index.html", include('inc/index.html.inc'));


### PR DESCRIPTION
ThemeRoller server use PHP 5.3 by any chance ? 
zip.php file use PHP 5.4 syntax.

I think this may cause of
#193

and
#194

My local PHP 5.3 environment run correctly with this commit.
